### PR TITLE
Update Aspire v13

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup Label="Package Versions">
     <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
     <EntityFrameworkCoreVersion>10.0.0</EntityFrameworkCoreVersion>
-    <AspireVersion>9.5.2</AspireVersion>
+    <AspireVersion>13.0.0</AspireVersion>
     <OpenTelemetryVersion>1.12.0</OpenTelemetryVersion>
   </PropertyGroup>
   <ItemGroup Label="Generic Packages">
@@ -18,12 +18,11 @@
     <PackageVersion Include="Scalar.AspNetCore" Version="2.4.13" />
   </ItemGroup>
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(AspireVersion)" />
-		<PackageVersion Include="Aspire.Hosting.DevTunnels" Version="9.5.2-preview.1.25522.3" />
+    <PackageVersion Include="Aspire.Hosting.Javascript" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="$(AspireVersion)-preview.1.25560.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
     <EntityFrameworkCoreVersion>10.0.0</EntityFrameworkCoreVersion>
     <AspireVersion>13.0.0</AspireVersion>
-    <OpenTelemetryVersion>1.12.0</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.14.0</OpenTelemetryVersion>
   </PropertyGroup>
   <ItemGroup Label="Generic Packages">
     <PackageVersion Include="FastEndpoints" Version="7.0.1" />

--- a/src/aspire/Starlights.AppHost/AppHost.cs
+++ b/src/aspire/Starlights.AppHost/AppHost.cs
@@ -31,7 +31,7 @@ if (builder.ExecutionContext.IsRunMode)
 
 if (builder.ExecutionContext.IsRunMode)
 {
-    builder.AddNpmApp("react-builder-app", "../../frontend/builder-app", "dev")
+    builder.AddJavaScriptApp("react-builder-app", "../../frontend/builder-app", "dev")
         .WithEnvironment("BROWSER", "none")
         .WithHttpEndpoint(env: "PORT")
         .WithExternalHttpEndpoints()
@@ -49,7 +49,7 @@ if (builder.ExecutionContext.IsRunMode)
         .WithAnonymousAccess()
         .WithExplicitStart();
 
-    var app = builder.AddNpmApp("dev-tunnel-react-builder-app", "../../frontend/builder-app", "dev")
+    var app = builder.AddJavaScriptApp("dev-tunnel-react-builder-app", "../../frontend/builder-app", "dev")
         .WithIconName("Cloud", IconVariant.Regular)
         .WithHttpEndpoint(env: "PORT")
         .WithExternalHttpEndpoints()

--- a/src/aspire/Starlights.AppHost/Starlights.AppHost.csproj
+++ b/src/aspire/Starlights.AppHost/Starlights.AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.0.0"> 
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.DevTunnels" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request updates the Aspire dependencies and related configuration to use the latest versions, and migrates from the deprecated NodeJs hosting packages and APIs to the new JavaScript hosting equivalents. The changes ensure compatibility with Aspire 13.0.0 and modernize how JavaScript applications are hosted within the project.

Dependency and package updates:

* Upgraded the Aspire version from 9.5.2 to 13.0.0, and OpenTelemetry from 1.12.0 to 1.14.0 in `Directory.Packages.props`.
* Updated Aspire-related package references: replaced `Aspire.Hosting.NodeJs` with `Aspire.Hosting.JavaScript`, updated `Aspire.Hosting.DevTunnels` to use the new versioning scheme, and adjusted other related package versions for compatibility. 