### PR TITLE
replace FluentAssertions with AwesomeAssertions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ These guidelines are tailored to this repository. They consolidate prior guidanc
 - **Frontend**: React 19 (TypeScript) with Vite, TanStack Query, React Router, Tailwind CSS, and Shadcn UI
 - **Data**: Entity Framework Core 10 with SQL Server
 - **Orchestration**: .NET Aspire 9.5 for local development and Azure deployment
-- **Testing**: MSTest for unit tests; FluentAssertions for assertions; Moq for mocking
+- **Testing**: MSTest for unit tests; AwesomeAssertions for assertions; Moq for mocking
 - **Observability**: Serilog for logging, OpenTelemetry for distributed tracing and metrics
 
 ## C# Practices
@@ -119,7 +119,7 @@ These guidelines are tailored to this repository. They consolidate prior guidanc
 - **TypeScript**: Strict mode enabled; proper typing for all components and functions.
 - **Environment**: Use `VITE_API_BASE` for API base URL (injected by Aspire in development).
 
-## Unit Testing (MSTest + FluentAssertions + Moq)
+## Unit Testing (MSTest + AwesomeAssertions + Moq)
 
 - **Structure**:
   - Clear test names: `Class_Method_Scenario` or `Method_WhenCondition_ExpectedBehavior`
@@ -127,7 +127,7 @@ These guidelines are tailored to this repository. They consolidate prior guidanc
   - Use `[DataRow]` for parameterized tests
 - **Style**:
   - Follow AAA pattern (Arrange, Act, Assert)
-  - Use FluentAssertions exclusively for assertions
+  - Use AwesomeAssertions exclusively for assertions
   - Use Moq with strong typing and strict behavior where critical
 - **Coverage Requirements** for any new component (class/record/struct):
   - Construction and defaults

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,15 +25,6 @@ updates:
     labels:
       - "dependencies"
       - "nuget"
-    ignore:
-      # Explicitly exclude FluentAssertions from automatic updates
-      - dependency-name: "FluentAssertions"
-        update-types:
-          [
-            "version-update:semver-major",
-            "version-update:semver-minor",
-            "version-update:semver-patch",
-          ]
     groups:
       microsoft-packages:
         patterns:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,6 @@
 
 	<ItemGroup Label="Test Projects" Condition="$(MSBuildProjectName.EndsWith('Tests'))">
 		<PackageReference Include="Moq" />
-		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="AwesomeAssertions" />
 	</ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,6 @@
 <Project>
 	<Target Name="EnforceSpecificVersions" BeforeTargets="Build">
-		<!-- FluentAssertions version 7.2.0 -->
-		<ItemGroup>
-			<FluentAssertionsPackage Include="@(PackageVersion)" Condition="'%(Identity)' == 'FluentAssertions'" />
-		</ItemGroup>
-		<Error Condition="$([System.Version]::Parse('%(FluentAssertionsPackage.Version)')) > $([System.Version]::Parse('7.2.0'))" Text="The last free version of Fluent Assertions is version 7.x. Version 8.0 and later versions require a paid license for commercial use, while remaining free for open-source and non-commercial projects. You currently include version: '%(FluentAssertionsPackage.Version)'" />
+
+		<!-- look at the git history how to enforce a package on a specific version -->
 	</Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Javascript" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="$(AspireVersion)-preview.1.25560.3" />
+    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="13.0.2-preview.1.25603.5" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup Label="Test Projects">
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup Label="Source Generator Projects" Condition="$(MSBuildProjectName.EndsWith('SourceGenerators'))">

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _This is a screenshot from the experimental Development UI in this project._
 ### Testing
 
 - **MSTest**: Test framework
-- **FluentAssertions**: Expressive assertion library
+- **AwesomeAssertions**: Expressive assertion library
 - **Moq**: Mocking framework for unit tests
 - Integration tests using WebApplicationFactory pattern
 

--- a/src/modules/characters/Modules.Characters.Tests/Characters/AbilityScoreTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/AbilityScoreTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Abilities;
 using Starlights.Modules.Characters.Domain.Registrations;
 

--- a/src/modules/characters/Modules.Characters.Tests/Characters/CharacterAbilitiesUpdateServiceTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/CharacterAbilitiesUpdateServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Abilities;
 using Starlights.Modules.Characters.Domain.Abilities.Eventing;
 using Starlights.Modules.Characters.Domain.Characters;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/CharacterClassTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/CharacterClassTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Classes;
 using Starlights.Modules.Characters.Domain.Registrations;
 

--- a/src/modules/characters/Modules.Characters.Tests/Characters/CharacterComponentsTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/CharacterComponentsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Progression;
 

--- a/src/modules/characters/Modules.Characters.Tests/Characters/CharacterDomainServiceTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/CharacterDomainServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Starlights.Modules.Characters.Domain.Characters;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/CharacterTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/CharacterTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 
 namespace Starlights.Modules.Characters.Tests.Characters;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/ClassComponentTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/ClassComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Classes;
 using Starlights.Modules.Characters.Domain.Classes.Eventing;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/SavingThrowTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/SavingThrowTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Abilities;
 using Starlights.Modules.Characters.Domain.Registrations;
 using Starlights.Modules.Characters.Domain.SavingThrows;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/SkillTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/SkillTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Abilities;
 using Starlights.Modules.Characters.Domain.Registrations;
 using Starlights.Modules.Characters.Domain.Skills;

--- a/src/modules/characters/Modules.Characters.Tests/Characters/UpdateSavingThrowsEventHandlerTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Characters/UpdateSavingThrowsEventHandlerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using Starlights.Modules.Characters.Data;
 using Starlights.Modules.Characters.Domain.Abilities;

--- a/src/modules/characters/Modules.Characters.Tests/ProgressionComponentTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/ProgressionComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Progression;
 

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationIncludeRuleTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationIncludeRuleTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Elements;
 using Starlights.Modules.Characters.Domain.Registrations;

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationProcessingContextTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationProcessingContextTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Classes;

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationProcessorTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationProcessorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationSelectionRuleTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationSelectionRuleTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Elements;
 using Starlights.Modules.Characters.Domain.Registrations;

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationStatisticRuleTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationStatisticRuleTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Elements;
 using Starlights.Modules.Characters.Domain.Registrations;

--- a/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Registrations/RegistrationTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Characters.Domain.Characters;
 using Starlights.Modules.Characters.Domain.Elements;
 using Starlights.Modules.Characters.Domain.Registrations;

--- a/src/modules/characters/Modules.Characters.Tests/Statistics/StatisticValuesGroupCollectionTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Statistics/StatisticValuesGroupCollectionTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Characters.Services.Statistics;
 
 namespace Starlights.Modules.Characters.Tests.Statistics;

--- a/src/modules/characters/Modules.Characters.Tests/Statistics/StatisticsCalculatorTests.cs
+++ b/src/modules/characters/Modules.Characters.Tests/Statistics/StatisticsCalculatorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Starlights.Modules.Characters.Domain.Abilities;
 using Starlights.Modules.Characters.Domain.Characters;

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/AbbreviationComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/AbbreviationComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/AbilityComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/AbilityComponentTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/DescriptionComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/DescriptionComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/IncludeRuleComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/IncludeRuleComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/LanguageComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/LanguageComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/PrerequisitesComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/PrerequisitesComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/PrimaryAbilityComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/PrimaryAbilityComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/SelectionRuleComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/SelectionRuleComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/ShortDescriptionComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/ShortDescriptionComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/SortingComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/SortingComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/Components/StatisticRuleComponentTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/Components/StatisticRuleComponentTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/ElementComponentOrderingTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/ElementComponentOrderingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Starlights.Modules.Elements.Data;
 using Starlights.Modules.Elements.Domain;

--- a/src/modules/elements/Modules.Elements.Tests/Domain/ElementConstructionTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/ElementConstructionTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/Domain/ElementsTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/Domain/ElementsTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Modules.Elements.Domain;
 using Starlights.Modules.Elements.Domain.Components;
 

--- a/src/modules/elements/Modules.Elements.Tests/ElementsModuleQueriesTests.cs
+++ b/src/modules/elements/Modules.Elements.Tests/ElementsModuleQueriesTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Moq;
 using Starlights.Modules.Elements.Data;
 using Starlights.Modules.Elements.Domain;

--- a/src/platform/Starlights.Platform.Tests/DomainTests.cs
+++ b/src/platform/Starlights.Platform.Tests/DomainTests.cs
@@ -1,5 +1,5 @@
 ﻿
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Platform.Domain;
 using Starlights.Platform.Eventing;
 

--- a/src/platform/Starlights.Platform.Tests/PlatformTests.cs
+++ b/src/platform/Starlights.Platform.Tests/PlatformTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;

--- a/src/platform/components/Starlights.Platform.Components.Data.EntityFramework.Tests/DomainEventPublisherTests.cs
+++ b/src/platform/components/Starlights.Platform.Components.Data.EntityFramework.Tests/DomainEventPublisherTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Starlights.Platform.Eventing;

--- a/src/tests/integration/Starlights.Integration.Tests/Core/HttpClientExtensions.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Core/HttpClientExtensions.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace Starlights.Integration.Core;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/AbilityScoreDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/AbilityScoreDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Models;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/AbilityScoresEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/AbilityScoresEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Modules.Characters.Endpoints.Characters.AbilityScores.GetAbilities;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Constants;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Eventing;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationEndpointDriver.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Characters.CreateCharacter;
 using Starlights.Modules.Characters.Endpoints.Characters.GetCharacterDetails;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationOptionsDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterCreationOptionsDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Generation.CreationOptions;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterManagementDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterManagementDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Modules.Characters.Endpoints.Characters.GetCharacterClasses;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterManagementEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterManagementEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Characters.GetCharacterClasses;
 using Starlights.Modules.Characters.Endpoints.Characters.LevelUp;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterPortraitDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/CharacterPortraitDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Generation.PortraitOptions;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/RegistrationDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/RegistrationDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Constants;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Eventing;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/RegistrationEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/RegistrationEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Modules.Characters.Endpoints.Generation.Registrations.GetRegistrations;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SavingThrowDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SavingThrowDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Characters.SavingThrows;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SavingThrowEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SavingThrowEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Modules.Characters.Endpoints.Characters.SavingThrows.GetSavingThrows;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SkillsDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SkillsDriver.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Characters.Endpoints.Characters.Skills;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SkillsEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/CharacterCreation/SkillsEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Modules.Characters.Endpoints.Characters.Skills.GetSkills;

--- a/src/tests/integration/Starlights.Integration.Tests/Drivers/Elements/ElementsEndpointDriver.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Drivers/Elements/ElementsEndpointDriver.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 
 namespace Starlights.Integration.Drivers.Elements;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/AbilityScoresEndpointsTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/AbilityScoresEndpointsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterCreationOptionsTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterCreationOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterCreationTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterCreationTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterPortraitOptionsTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/CharacterPortraitOptionsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/ClassTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/ClassTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Eventing;
 using Starlights.Integration.Core.Extensions;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/DeleteCharacterEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/DeleteCharacterEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/GetCharactersEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Manage/GetCharactersEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/GetRegistrationsEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/GetRegistrationsEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/RegisterSelectionRuleEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/RegisterSelectionRuleEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Constants;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/UnregisterSelectionRuleEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Registration/UnregisterSelectionRuleEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Constants;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/SavingThrowsEndpointsTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/SavingThrowsEndpointsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Sheet/GetFeaturesEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Sheet/GetFeaturesEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/SkillsEndpointsTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/SkillsEndpointsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Extensions;
 using Starlights.Integration.Drivers.CharacterCreation;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Statistics/GetStatisticsEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/Statistics/GetStatisticsEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Eventing;
 using Starlights.Integration.Core.Extensions;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/UpdateClassLevelEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Characters/UpdateClassLevelEndpointTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Integration.Core.Eventing;
 using Starlights.Integration.Core.Extensions;

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Elements/AbilitiesEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Elements/AbilitiesEndpointTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Starlights.Integration.Core;
 using Starlights.Modules.Elements.Endpoints.Entities.Abilities.GetAbilities;
 

--- a/src/tests/integration/Starlights.Integration.Tests/Tests/Elements/ElementsEndpointTests.cs
+++ b/src/tests/integration/Starlights.Integration.Tests/Tests/Elements/ElementsEndpointTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Starlights.Integration.Core;
 


### PR DESCRIPTION
This pull request migrates the test assertion library from FluentAssertions to AwesomeAssertions across the codebase, updates related documentation and configuration. These changes ensure consistency in testing practices and keep dependencies up to date.

**Testing Library Migration:**

* Replaced all usages of `FluentAssertions` with `AwesomeAssertions` in test files. This includes updating the `using` statements in all relevant test classes. 

**Documentation and Configuration Updates:**

* Updated `.github/copilot-instructions.md` and `README.md` to reference `AwesomeAssertions` instead of `FluentAssertions` in testing guidelines and tool lists.
* Removed the explicit ignore rule for `FluentAssertions` from `dependabot` configuration, as it is no longer used.