### PR TITLE
chore: update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup Label="Package Versions">
     <MicrosoftExtensionsVersion>10.0.1</MicrosoftExtensionsVersion>
     <EntityFrameworkCoreVersion>10.0.1</EntityFrameworkCoreVersion>
-    <AspireVersion>13.0.2</AspireVersion>
+    <AspireVersion>13.1.0</AspireVersion>
     <OpenTelemetryVersion>1.14.0</OpenTelemetryVersion>
   </PropertyGroup>
   <ItemGroup Label="Generic Packages">
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Javascript" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="13.0.2-preview.1.25603.5" />
+    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="$(AspireVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <MicrosoftExtensionsVersion>10.0.1</MicrosoftExtensionsVersion>
-    <EntityFrameworkCoreVersion>10.0.1</EntityFrameworkCoreVersion>
+    <MicrosoftExtensionsVersion>10.0.2</MicrosoftExtensionsVersion>
+    <EntityFrameworkCoreVersion>10.0.2</EntityFrameworkCoreVersion>
     <AspireVersion>13.1.0</AspireVersion>
-    <OpenTelemetryVersion>1.14.0</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.15.0</OpenTelemetryVersion>
   </PropertyGroup>
   <ItemGroup Label="Generic Packages">
     <PackageVersion Include="FastEndpoints" Version="7.1.1" />
@@ -18,8 +18,8 @@
     <PackageVersion Include="Scalar.AspNetCore" Version="2.11.6" />
   </ItemGroup>
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Javascript" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="$(AspireVersion)" />

--- a/src/aspire/Starlights.AppHost/Starlights.AppHost.csproj
+++ b/src/aspire/Starlights.AppHost/Starlights.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.0.2"> 
+<Project Sdk="Aspire.AppHost.Sdk/13.1.0"> 
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Dependency version upgrades:

* Updated central package versions in `Directory.Packages.props`:
  - `MicrosoftExtensionsVersion` and `EntityFrameworkCoreVersion` to `10.0.2`
  - `AspireVersion` to `13.1.0`
  - `OpenTelemetryVersion` to `1.15.0`
* Upgraded Aspire-related package references:
  - `Microsoft.Extensions.ServiceDiscovery` and `Microsoft.Extensions.Http.Resilience` to `10.2.0`
  - `Aspire.Hosting.DevTunnels` to use the new `$(AspireVersion)` property for versioning
* Bumped the SDK version in `Starlights.AppHost.csproj` to use `Aspire.AppHost.Sdk/13.1.0`